### PR TITLE
write command

### DIFF
--- a/bin/todo
+++ b/bin/todo
@@ -2,7 +2,7 @@
 
 /*!
  * todo - Todos in the CLI like what.
- * 
+ *
  * Veselin Todorov <hi@vesln.com>
  * MIT License.
  */

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,6 +1,6 @@
 /*!
  * todo - Todos in the CLI like what.
- * 
+ *
  * Veselin Todorov <hi@vesln.com>
  * MIT License.
  */
@@ -13,7 +13,7 @@ var path = require('path');
 
 /**
  * The application object.
- * 
+ *
  * @type {Object}
  */
 var app = module.exports = flatiron.app;
@@ -33,6 +33,7 @@ app.use(flatiron.plugins.cli, {
     '       todo undo 1       - Marks #1 item as not done yet.',
     '       todo clear        - Clears the whole list.',
     '       todo version      - Lib version.',
+    '       todo write        - Write items to file.',
     '',
     'Author: Veselin Todorov <hi@vesln.com>'
   ]

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,20 +1,20 @@
 /*!
  * todo - Todos in the CLI like what.
- * 
+ *
  * Veselin Todorov <hi@vesln.com>
  * MIT License.
  */
 
 /**
  * The application object.
- * 
+ *
  * @type {Object}
  */
 var app = module.exports = require('./app')
 
 /**
  * Commands.
- * 
+ *
  * @type {Object}
  */
 var commands = require('./commands');
@@ -36,6 +36,9 @@ app.cmd(/undo (.+)/, commands.undo);
 
 // Removes a todo item.
 app.cmd(/rm (.+)/, commands.delete);
+
+// Writes todo to file.
+app.cmd(/write (.+)/, commands.write);
 
 // Adds new todo item.
 app.cmd(/(.+)/, commands.add);

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,48 +1,53 @@
 /*!
  * todo - Todos in the CLI like what.
- * 
+ *
  * Veselin Todorov <hi@vesln.com>
  * MIT License.
  */
- 
+
 /**
  * Commands namespace.
- * 
+ *
  * @type {Object}
  */
 var commands = module.exports;
 
 /**
  * Print alias.
- * 
+ *
  * @api private
  */
 commands.print = console.log;
 
 /**
  * The application.
- * 
+ *
  * @type {Object}
  */
 var app = require('./app');
 
 /**
  * Storage. Just an alias to application config.
- * 
+ *
  * @type {Object}
  */
 var storage = require('./storage');
 
 /**
  * Formatter.
- * 
+ *
  * @type {Object}
  */
 var formatter = require('./formatter');
 
 /**
+ * File writing.
+ */
+var fs = require('fs');
+
+/**
  * Prints current version.
- * 
+ *
  * @api public
  */
 commands.version = function() {
@@ -51,7 +56,7 @@ commands.version = function() {
 
 /**
  * Lists todo items.
- * 
+ *
  * @api public
  */
 commands.list = function() {
@@ -62,7 +67,7 @@ commands.list = function() {
       if (!app.argv.all && items[i].done) continue;
       out.push(formatter.format(items[i], i + 1));
     }
-    
+
     out.push('') && out.unshift('');
     out.map(function(line) {
       commands.print(line);
@@ -72,7 +77,7 @@ commands.list = function() {
 
 /**
  * Marks an item as done.
- * 
+ *
  * @param {String} Number.
  * @api public
  */
@@ -83,7 +88,7 @@ commands.check = function(num) {
 
 /**
  * Undo a check for item.
- * 
+ *
  * @param {String} Number.
  * @api public
  */
@@ -94,7 +99,7 @@ commands.undo = function(num) {
 
 /**
  * Toggles an item state.
- * 
+ *
  * @param {Number} Item index.
  * @param {Boolean} State.
  * @api private
@@ -114,7 +119,7 @@ commands.toggle = function(num, state) {
 
 /**
  * Deletes an item.
- * 
+ *
  * @param {String} Todo item number.
  * @api public
  */
@@ -133,7 +138,7 @@ commands.delete = function(num) {
 
 /**
  * Clears the whole todo item.
- * 
+ *
  * @param {String} Todo item number.
  * @api public
  */
@@ -147,7 +152,7 @@ commands.clear = function(num) {
 
 /**
  * Adds new item to the todo list.
- * 
+ *
  * @param {String} Item description.
  * @api public
  */
@@ -159,6 +164,37 @@ commands.add = function(item) {
       storage.save(function(err) {
         if (err) throw err;
       });
+    });
+  });
+};
+
+/**
+ * Prints the todo list to a file.
+ *
+ * @param {String} File location/name
+ * @api public
+ */
+commands.write = function(filename) {
+  var data = '';
+  if (!filename) {
+    var filename = "~/todo.txt";
+  }
+  var out = [];
+  storage.get('items', function(err, items) {
+    items || (items = []);
+    for (var i = -1, len = items.length; ++i < len;) {
+      if (!app.argv.all && items[i].done) continue;
+      out.push(formatter.format(items[i], i + 1));
+    }
+
+    out.push('') && out.unshift('');
+    out.map(function(line) {
+      console.log(line);
+      data += line +"\n";
+    });
+    fs.writeFile(filename, data, 'utf8', function(err, written) {
+      if (err) return console.log(err);
+
     });
   });
 };


### PR DESCRIPTION
Introduces the
    todo write
command.

I've added a write command to my version which by default outputs the formatted items to ~/todo.txt

Originally I wanted to display my todo list through geektool on my desktop, and couldn't seem to get geektool to successfully get the output of 'todo ls'. 

Now I just have geektool set to 'cat ~/todo.txt' and write to the file when I want it updated with 'todo write ~/todo.txt'

Next step is to see if I can automatically chain commands, calling command.write after any command that changes the list.
