### PR TITLE
Removes erroneous period from help output

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -26,7 +26,7 @@ app.use(flatiron.plugins.cli, {
     'Usage:',
     '',
     '       todo Go shopping. - Adds new item.',
-    '       todo ls.          - Lists not finished items.',
+    '       todo ls           - Lists not finished items.',
     '       todo ls --all     - Lists all items.',
     '       todo rm 1         - Removes #1 item.',
     '       todo check 1      - Marks #1 item as done.',


### PR DESCRIPTION
Running `todo ls.` causes a new todo item to be inserted.
