### PR TITLE
Add `renumber` to reset ids starting with 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     todo rm 1                Remove #1 item
     todo clear               Destroy all todo items
     todo clear --done        Destroy all completed todo items
+    todo renumber            Re-numbers all todos starting with 1
 
   Environment variables:
 

--- a/lib/cli/help.js
+++ b/lib/cli/help.js
@@ -29,6 +29,7 @@ module.exports = function() {
     '    todo rm 1                Remove #1 item',
     '    todo clear               Destroy all todo items',
     '    todo clear --done        Destroy all completed todo items',
+    '    todo renumber            Re-numbers all todos starting with 1',
     '',
     '  Environment variables:',
     '',

--- a/lib/cli/renumber.js
+++ b/lib/cli/renumber.js
@@ -1,0 +1,16 @@
+/**
+ * Re-numbers.
+ *
+ * Example:
+ *
+ *     $ todo renumber
+ *
+ * @param {Object} argv
+ * @param {Todos} todos
+ * @returns {Array}
+ * @api public
+ */
+
+module.exports = function(argv, todos) {
+  return todos.renumber();
+};

--- a/lib/todos.js
+++ b/lib/todos.js
@@ -138,6 +138,22 @@ Todos.prototype = {
   },
 
   /**
+   * Re-numbers todos starting with 1.
+   *
+   * @returns {Array}
+   * @api public
+   */
+
+  renumber: function() {
+    var list = this.list('all').map(function(todo, i) {
+      todo.id = i + 1;
+      return todo;
+    });
+    this.save(list);
+    return list;
+  },
+
+  /**
    * Return the next todo id.
    *
    * @returns {Number}

--- a/test/acceptance/renumber.js
+++ b/test/acceptance/renumber.js
@@ -1,0 +1,12 @@
+describe('todo renumber', function() {
+  it('renumbers all todos starting at 1', function(done) {
+    cli()
+    .exec('todo add have more fun')
+    .exec('todo mv 1 2')
+    .exec('todo renumber')
+    .run('todo ls')
+    .stdout('1. have more fun')
+    .code(0)
+    .end(done);
+  });
+});

--- a/test/todos.js
+++ b/test/todos.js
@@ -154,7 +154,7 @@ describe(Todos, function() {
   describe('#clear', function() {
     it('clears todos with give status', function() {
       var todos = new Todos(storage);
-      
+
       time.freeze();
 
       jack(storage, 'write');
@@ -207,6 +207,20 @@ describe(Todos, function() {
       todos.mv(1, 2);
 
       actual.should.eql([2, 1]);
+    });
+  });
+
+  describe('#renumber', function() {
+    it('renumbers the todo items', function() {
+      var todos = new Todos(storage);
+
+      time.freeze();
+      jack(storage, 'write');
+      jack(storage, 'read', function() { return [ completed ]; });
+
+      todos.renumber();
+
+      storage.write.should.have.been.called.with.args([ new Todo(1, 'desc', 'done') ]);
     });
   });
 });


### PR DESCRIPTION
After using this for a few weeks, I got up into double digits which is kind of annoying to type to check off (I'm really lazy and have ocd).

This along with #21 allow you to do:

![](http://g.recordit.co/869tLkOmOI.gif)

As with #21, if this is something you're interested in merging, please let me know any changes to make.

I suck at naming and I'm not too fond of `renumber` so if there is something else or a shorter version you can think of, I'm open to it.